### PR TITLE
Add php timezone to env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ ENV DOLI_NO_CSRF_CHECK 0
 ENV PHP_INI_upload_max_filesize=50M
 ENV PHP_INI_memory_limit=256M
 ENV PHP_INI_max_execution_time=60
+ENV PHP_INI_date.timezone="Europe/Paris"
 
 ENV LANG fr_FR
 


### PR DESCRIPTION
Changes made to docker-compose file are not picked up unless the env variable is set in the dockerfile.
Setting up the same php timezone as your server timezone is mandatory in order to create fail2ban rules to secure access to dolibarr and moreover your server hosting it.

By the way, thanks for your work!