### PR TITLE
Bump dolibarr version to 13.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	rm -rf /var/www/localhost/htdocs; \
 	ln -s /var/www/html /var/www/localhost/htdocs
 
-ENV DOLI_VERSION 12.0.4
+ENV DOLI_VERSION 13.0.2
 
 ENV DOLI_DB_TYPE mysqli
 ENV DOLI_DB_HOST db

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN set -eux; \
 		php7-mbstring \
 		php7-intl \
 		php7-gd \
+		php7-imap \
 		php7-imagick \
 		php7-soap \
 		php7-curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ ENV DOLI_NO_CSRF_CHECK 0
 ENV PHP_INI_upload_max_filesize=50M
 ENV PHP_INI_memory_limit=256M
 ENV PHP_INI_max_execution_time=60
+ENV PHP_INI_post_max_size=8M
 
 ENV LANG fr_FR
 


### PR DESCRIPTION
- Update to Dolibar version `13.0.2`, fix https://github.com/upshift-docker/dolibarr/issues/13
- Add `PHP_INI_post_max_size` to Dockerfile as `post_max_size` should be greater or equal to `upload_max_filesize`
- Add missing php dependency` php7-imap`
